### PR TITLE
docs: fix simple typo, contaning -> containing

### DIFF
--- a/example.py
+++ b/example.py
@@ -8,7 +8,7 @@ def get_foo():
     """Get some foo.
 
     Returns:
-        A string contaning a nice foo.
+        A string containing a nice foo.
     """
     return "foo"
 


### PR DESCRIPTION
There is a small typo in example.py.

Should read `containing` rather than `contaning`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md